### PR TITLE
Fix prerelease pipeline pack step

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -48,7 +48,7 @@ jobs:
           name: build-output
           path: |
             src/Boolit.net/bin/Release/
-            src/Boolit.net/obj/Release/
+            src/Boolit.net/obj/
 
   package:
     needs: build-matrix


### PR DESCRIPTION
Included all of obj folder to ensure NuGet metadata files are included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the workflow to upload the entire build object directory, ensuring all relevant files are included in the build artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->